### PR TITLE
Fixed the ch atribute elements always being set to ' ', regardless of input.

### DIFF
--- a/lib/widgets/element.js
+++ b/lib/widgets/element.js
@@ -115,14 +115,15 @@ function Element(options) {
     bottom: options.padding.bottom || 0
   };
 
-  this.border = options.border;
+  this.border = options.border || options.style.border;
   if (this.border) {
     if (typeof this.border === 'string') {
       this.border = { type: this.border };
     }
     this.border.type = this.border.type || 'bg';
     if (this.border.type === 'ascii') this.border.type = 'line';
-    this.border.ch = this.border.ch || ' ';
+    this.border.ch = this.border.ch || this.style.border.ch || ' ';
+    if (this.border.ch.length > 1) this.border.ch = this.border.ch.charAt(0)
     this.style.border = this.style.border || this.border.style;
     if (!this.style.border) {
       this.style.border = {};
@@ -1873,7 +1874,6 @@ Element.prototype.render = function() {
     , visible
     , i
     , bch = this.ch;
-
   // Clip content if it's off the edge of the screen
   // if (xi + this.ileft < 0 || yi + this.itop < 0) {
   //   var clines = this._clines.slice();
@@ -2134,6 +2134,7 @@ Element.prototype.render = function() {
 
   // Draw the border.
   if (this.border) {
+    ch = bch
     battr = this.sattr(this.style.border);
     y = yi;
     if (coords.notop) y = -1;
@@ -2177,7 +2178,6 @@ Element.prototype.render = function() {
         ch = this.border.ch;
       }
       if (!this.border.top && x !== xi && x !== xl - 1) {
-        ch = ' ';
         if (dattr !== cell[0] || ch !== cell[1]) {
           lines[y][x][0] = dattr;
           lines[y][x][1] = ch;
@@ -2209,7 +2209,6 @@ Element.prototype.render = function() {
             lines[y].dirty = true;
           }
         } else {
-          ch = ' ';
           if (dattr !== cell[0] || ch !== cell[1]) {
             lines[y][xi][0] = dattr;
             lines[y][xi][1] = ch;
@@ -2232,7 +2231,6 @@ Element.prototype.render = function() {
             lines[y].dirty = true;
           }
         } else {
-          ch = ' ';
           if (dattr !== cell[0] || ch !== cell[1]) {
             lines[y][xl - 1][0] = dattr;
             lines[y][xl - 1][1] = ch;
@@ -2283,7 +2281,6 @@ Element.prototype.render = function() {
         ch = this.border.ch;
       }
       if (!this.border.bottom && x !== xi && x !== xl - 1) {
-        ch = ' ';
         if (dattr !== cell[0] || ch !== cell[1]) {
           lines[y][x][0] = dattr;
           lines[y][x][1] = ch;


### PR DESCRIPTION
border.ch can now be defined in style.

The following code:
```js
var example = blessed.box({
   top: 'center',
   left: 'center',
   width: '50%',
   height: '50%',
   ch: '@'
});
```
Will now create a box full of @ symbols. This is useful for a background. Also, you can now define the character for a bg type border in border.style.